### PR TITLE
Typings fix

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -56,7 +56,7 @@ export async function uuidForNames(names : Array<string>){
  */
 export interface NameHistoryResponseModel {
     name: string,
-    changedTo: string|null
+    changedToAt: number|null
 }
 
 /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -670,9 +670,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.15",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+      "version": "4.17.19",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
+      "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==",
       "dev": true
     },
     "log-symbols": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "minecraft-api",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "main": "index.js",
   "types": "index.d.ts",
   "scripts": {


### PR DESCRIPTION
The Mojang API now has `changedToAt` instead of `changedTo` for the [Name history](https://wiki.vg/Mojang_API#UUID_-.3E_Name_history) API endpoint. The type has also been changed from `string` to a `number` due to the response sending back a Java timestamp in milliseconds.