### PR TITLE
Update types for NameHistoryResponseModel to current Mojang API

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -56,7 +56,7 @@ export async function uuidForNames(names : Array<string>){
  */
 export interface NameHistoryResponseModel {
     name: string,
-    changedTo: string|null
+    changedToAt: number|null
 }
 
 /**


### PR DESCRIPTION
The Mojang API seems to have the `changedToAt` property instead of the `changedTo` property for the [Name history](https://wiki.vg/Mojang_API#UUID_-.3E_Name_history) API endpoint. The type for this property has also been changed from `string` to `number` due to the response sending back a Java timestamp in milliseconds.